### PR TITLE
guard for delay if diff is negative

### DIFF
--- a/src/Altinn.Notifications.Email.Integrations/Consumers/EmailSendingAcceptedConsumer.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Consumers/EmailSendingAcceptedConsumer.cs
@@ -58,7 +58,7 @@ public sealed class EmailSendingAcceptedConsumer : KafkaConsumerBase
 
         int diff = (int)(_dateTime.UtcNow() - operationIdentifier.LastStatusCheck).TotalMilliseconds;
 
-        if (diff < _processingDelay)
+        if (diff > 0 && diff < _processingDelay)
         {
             await Task.Delay(_processingDelay - diff);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bug identified when operation update is not returned from communication services within reasonable time (> 30 days).
Guard to avoid argument exception with negative int, because int out of bounds