### PR TITLE
Handle suppressed recipients more gracefully

### DIFF
--- a/src/Altinn.Notifications.Email.Integrations/Clients/AzureCommunicationServices/ErrorTypes.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Clients/AzureCommunicationServices/ErrorTypes.cs
@@ -1,0 +1,22 @@
+namespace Altinn.Notifications.Email.Integrations.Clients.AzureCommunicationServices;
+
+/// <summary>
+/// Constants for error types returned from Azure Communication Services (ACS)
+/// </summary>
+public static class ErrorTypes
+{
+    /// <summary>
+    /// The error code returned when the call volume has exceeded the assigned quota for our Azure subscription
+    /// </summary>
+    public const string ExcessiveCallVolumeErrorCode = "TooManyRequests";
+
+    /// <summary>
+    /// The error code returned when the email recipient is found on the suppression list of ACS
+    /// </summary>
+    public const string RecipientsSuppressedErrorCode = "EmailDroppedAllRecipientsSuppressed";
+    
+    /// <summary>
+    /// The error message returned when the recipient email format is invalid
+    /// </summary>
+    public const string InvalidEmailFormatErrorMessage = "Invalid format for email address";
+}

--- a/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
@@ -21,14 +21,14 @@ namespace Altinn.Notifications.Email.Integrations.Clients;
 public class EmailServiceClient : IEmailServiceClient
 {
     private readonly EmailClient _emailClient;
-    private readonly ILogger<IEmailServiceClient> _logger;
+    private readonly ILogger<EmailServiceClient> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EmailServiceClient"/> class.
     /// </summary>
     /// <param name="communicationServicesSettings">Settings for integration against Communication Services.</param>
     /// <param name="logger">A logger</param>
-    public EmailServiceClient(CommunicationServicesSettings communicationServicesSettings, ILogger<IEmailServiceClient> logger)
+    public EmailServiceClient(CommunicationServicesSettings communicationServicesSettings, ILogger<EmailServiceClient> logger)
     {
         _emailClient = new EmailClient(communicationServicesSettings.ConnectionString);
         _logger = logger;

--- a/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
@@ -9,7 +9,6 @@ using Altinn.Notifications.Email.Integrations.Configuration;
 
 using Azure;
 using Azure.Communication.Email;
-
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.Notifications.Email.Integrations.Clients;
@@ -109,7 +108,15 @@ public class EmailServiceClient : IEmailServiceClient
         }
         catch (RequestFailedException e)
         {
-            _logger.LogError(e, "// EmailServiceClient // GetOperationUpdate // Exception thrown when getting status, OperationId {OperationId}", operationId);
+            if (e.ErrorCode == ErrorTypes.RecipientsSuppressedErrorCode)
+            {
+                _logger.LogWarning("A request failed because the recipient is on the suppression list of Azure Communcation Services, OperationId {OperationId}", operationId);
+            }
+            else
+            {
+                _logger.LogError(e, "// EmailServiceClient // GetOperationUpdate // Exception thrown when getting status, OperationId {OperationId}", operationId);
+            }
+
             return GetEmailSendResult(e);
         }
 

--- a/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
@@ -65,8 +65,10 @@ public class EmailServiceClient : IEmailServiceClient
         catch (RequestFailedException e)
         {
             _logger.LogError(e, "// EmailServiceClient // SendEmail // Failed to send email, NotificationId {NotificationId}", email.NotificationId);
-            EmailClientErrorResponse emailSendFailResponse = new();
-            emailSendFailResponse.SendResult = GetEmailSendResult(e);
+            EmailClientErrorResponse emailSendFailResponse = new()
+            {
+                SendResult = GetEmailSendResult(e)
+            };
 
             if (emailSendFailResponse.SendResult == Core.Status.EmailSendResult.Failed_TransientError)
             {

--- a/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
+++ b/src/Altinn.Notifications.Email.Integrations/Clients/EmailServiceClient.cs
@@ -97,7 +97,7 @@ public class EmailServiceClient : IEmailServiceClient
                     return Core.Status.EmailSendResult.Succeeded;
                 }
 
-                var response = operation.WaitForCompletionResponse();
+                var response = await operation.WaitForCompletionResponseAsync();
                 _logger.LogError(
                     "// EmailServiceClient // GetOperationUpdate // Operation {OperationId} failed with status {Status} and reason phrase {Reason}",
                     operationId,

--- a/src/Altinn.Notifications.Email/Program.cs
+++ b/src/Altinn.Notifications.Email/Program.cs
@@ -68,7 +68,7 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 {
     if (Directory.Exists("/altinn-appsettings"))
     {
-        logger.LogWarning("Reading altinn-dbsettings-secret.json.");
+        logger.LogInformation("Reading altinn-dbsettings-secret.json.");
         IFileProvider fileProvider = new PhysicalFileProvider("/altinn-appsettings");
         config.AddJsonFile(fileProvider, "altinn-dbsettings-secret.json", optional: true, reloadOnChange: true);
     }

--- a/src/Altinn.Notifications.Email/Program.cs
+++ b/src/Altinn.Notifications.Email/Program.cs
@@ -68,7 +68,6 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 {
     if (Directory.Exists("/altinn-appsettings"))
     {
-        logger.LogInformation("Reading altinn-dbsettings-secret.json.");
         IFileProvider fileProvider = new PhysicalFileProvider("/altinn-appsettings");
         config.AddJsonFile(fileProvider, "altinn-dbsettings-secret.json", optional: true, reloadOnChange: true);
     }

--- a/src/Altinn.Notifications.Email/Telemetry/RequestFilterProcessor.cs
+++ b/src/Altinn.Notifications.Email/Telemetry/RequestFilterProcessor.cs
@@ -10,12 +10,12 @@ namespace Altinn.Notifications.Email.Telemetry
     public class RequestFilterProcessor : BaseProcessor<Activity>
     {
         private const string RequestKind = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IHttpContextAccessor? _httpContextAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestFilterProcessor"/> class.
         /// </summary>
-        public RequestFilterProcessor(IHttpContextAccessor httpContextAccessor = null) : base()
+        public RequestFilterProcessor(IHttpContextAccessor? httpContextAccessor = null) : base()
         {
             _httpContextAccessor = httpContextAccessor;
         }
@@ -47,7 +47,7 @@ namespace Altinn.Notifications.Email.Telemetry
         /// <param name="activity">xx</param>
         public override void OnEnd(Activity activity)
         {
-            if (activity.OperationName == RequestKind && _httpContextAccessor.HttpContext is not null &&
+            if (activity.OperationName == RequestKind && _httpContextAccessor?.HttpContext is not null &&
                 _httpContextAccessor.HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out StringValues ipAddress))
             {
                 activity.SetTag("ipAddress", ipAddress.FirstOrDefault());


### PR DESCRIPTION
## Description
In order to prevent error-logging of suppressed email recipients, `EmailServiceClient.GetOperationUpdate` no longer blindly logs any RequestFailedException as error. A condition on error code has been added, used to separate the "email suppressed" scenario (to be logged as warning) from other exceptions (to be logged as errors).
A new static class `ErrorTypes` has been created for organizing Azure Communication Services (ACS) errors as `public` constants.

Additional unrelated changes:
- removing the warning-logging of _"Reading altinn-dbsettings-secret.json."_ in `Program`. This seems like a part of the general flow of the application with no apparent value from logging it.
- resolving a warning (CS8625) on nullability by treating `_httpContextAccessor `as a nullable reference type in `RequestFilterProcessor`

## Related Issue(s)
- [#757](https://github.com/orgs/Altinn/projects/20/views/11?filterQuery=&pane=issue&itemId=103687070&issue=Altinn%7Caltinn-notifications%7C757) (altinn-notifications)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
