### PR TITLE
Feature/1042 instant delivery endpoint

### DIFF
--- a/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
+++ b/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
@@ -1,0 +1,88 @@
+using Altinn.Notifications.Email.Core.Sending;
+using Altinn.Notifications.Email.Models.InstantEmail;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Altinn.Notifications.Email.Controllers;
+
+/// <summary>
+/// Controller for sending instant emails.
+/// </summary>
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("notifications/email/api/v1/instantemail/")]
+public class InstantEmailController : ControllerBase
+{
+    private readonly ISendingService _sendingService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstantEmailController"/> class.
+    /// </summary>
+    public InstantEmailController(ISendingService sendingService)
+    {
+        _sendingService = sendingService;
+    }
+
+    /// <summary>
+    /// Sends an email instantly to a single recipient.
+    /// </summary>
+    /// <param name="request">The request containing email content, content type, recipient, sender, subject, and notification ID.</param>
+    /// <returns>
+    /// Returns 200 (OK) when the email was successfully accepted by the service provider.
+    /// Returns 400 (Bad Request) with <see cref="ProblemDetails"/> when the request is invalid or contains improper formatting.
+    /// Returns 499 (Client Closed Request) with <see cref="ProblemDetails"/> when the client cancels the request before completion.
+    /// </returns>
+    [HttpPost("send")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "The email was accepted by the service provider.")]
+    [SwaggerResponse(400, "The request was invalid.", typeof(ProblemDetails))]
+    [SwaggerResponse(499, "The request was canceled before processing could complete.", typeof(ProblemDetails))]
+    public async Task<IActionResult> Send([FromBody] InstantEmailRequest request)
+    {
+        var emailDataModel = MapToEmail(request);
+
+        try
+        {
+            await _sendingService.SendAsync(emailDataModel);
+
+            return Ok();
+        }
+        catch (InvalidOperationException)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid email request",
+                Status = StatusCodes.Status400BadRequest,
+                Detail = "The request could not be processed due to invalid input or state."
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            return StatusCode(StatusCodes.Status499ClientClosedRequest, new ProblemDetails
+            {
+                Title = "Request terminated",
+                Status = StatusCodes.Status499ClientClosedRequest,
+                Detail = "The request was canceled before processing could complete."
+            });
+        }
+    }
+
+    /// <summary>
+    /// Maps an <see cref="InstantEmailRequest"/> to the <see cref="Core.Sending.Email"/> domain model.
+    /// </summary>
+    /// <param name="request">The incoming request containing sender, subject, body, recipient, content type, and notification ID.</param>
+    /// <returns>An <see cref="Core.Sending.Email"/> object populated with values from the request.</returns>
+    private static Core.Sending.Email MapToEmail(InstantEmailRequest request)
+    {
+        return new Core.Sending.Email(
+            notificationId: request.NotificationId,
+            subject: request.Subject,
+            body: request.Body,
+            fromAddress: request.Sender,
+            toAddress: request.Recipient,
+            contentType: request.ContentType);
+    }
+}

--- a/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
+++ b/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
@@ -12,7 +12,7 @@ namespace Altinn.Notifications.Email.Controllers;
 /// </summary>
 [ApiController]
 [ApiExplorerSettings(IgnoreApi = true)]
-[Route("notifications/email/api/v1/instantemail/")]
+[Route("notifications/email/api/v1/instantemail")]
 public class InstantEmailController : ControllerBase
 {
     private readonly ISendingService _sendingService;
@@ -34,7 +34,7 @@ public class InstantEmailController : ControllerBase
     /// Returns 400 (Bad Request) with <see cref="ProblemDetails"/> when the request is invalid or contains improper formatting.
     /// Returns 499 (Client Closed Request) with <see cref="ProblemDetails"/> when the client cancels the request before completion.
     /// </returns>
-    [HttpPost("send")]
+    [HttpPost]
     [Consumes("application/json")]
     [Produces("application/json")]
     [SwaggerResponse(202, "The email was accepted for processing.")]

--- a/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
+++ b/src/Altinn.Notifications.Email/Controllers/InstantEmailController.cs
@@ -30,14 +30,14 @@ public class InstantEmailController : ControllerBase
     /// </summary>
     /// <param name="request">The request containing email content, content type, recipient, sender, subject, and notification ID.</param>
     /// <returns>
-    /// Returns 200 (OK) when the email was successfully accepted by the service provider.
+    /// Returns 202 (Accepted) when the email was successfully accepted for processing.
     /// Returns 400 (Bad Request) with <see cref="ProblemDetails"/> when the request is invalid or contains improper formatting.
     /// Returns 499 (Client Closed Request) with <see cref="ProblemDetails"/> when the client cancels the request before completion.
     /// </returns>
     [HttpPost("send")]
     [Consumes("application/json")]
     [Produces("application/json")]
-    [SwaggerResponse(200, "The email was accepted by the service provider.")]
+    [SwaggerResponse(202, "The email was accepted for processing.")]
     [SwaggerResponse(400, "The request was invalid.", typeof(ProblemDetails))]
     [SwaggerResponse(499, "The request was canceled before processing could complete.", typeof(ProblemDetails))]
     public async Task<IActionResult> Send([FromBody] InstantEmailRequest request)
@@ -48,7 +48,7 @@ public class InstantEmailController : ControllerBase
         {
             await _sendingService.SendAsync(emailDataModel);
 
-            return Ok();
+            return Accepted();
         }
         catch (InvalidOperationException)
         {

--- a/src/Altinn.Notifications.Email/Models/InstantEmail/InstantEmailRequest.cs
+++ b/src/Altinn.Notifications.Email/Models/InstantEmail/InstantEmailRequest.cs
@@ -47,7 +47,7 @@ public record InstantEmailRequest
     public required EmailContentType ContentType { get; init; }
 
     /// <summary>
-    /// The unique identifier of the notification order, of which this email is a part.
+    /// The unique identifier for this specific email notification.
     /// </summary>
     [Required]
     [JsonPropertyName("notificationId")]

--- a/src/Altinn.Notifications.Email/Models/InstantEmail/InstantEmailRequest.cs
+++ b/src/Altinn.Notifications.Email/Models/InstantEmail/InstantEmailRequest.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using Altinn.Notifications.Email.Core.Sending;
+
+namespace Altinn.Notifications.Email.Models.InstantEmail;
+
+/// <summary>
+/// Represents a request model for sending an email to a single recipient instantly.
+/// </summary>
+public record InstantEmailRequest
+{
+    /// <summary>
+    /// The sender address of the email.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("sender")]
+    public required string Sender { get; init; }
+
+    /// <summary>
+    /// The recipient email address where the email will be sent.
+    /// </summary>
+    [Required]
+    [EmailAddress]
+    [JsonPropertyName("recipient")]
+    public required string Recipient { get; init; }
+
+    /// <summary>
+    /// The subject of the email.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("subject")]
+    public required string Subject { get; init; }
+
+    /// <summary>
+    /// The body content of the email.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// The content type of the email (Html or Plain).
+    /// </summary>
+    [Required]
+    [JsonPropertyName("contentType")]
+    public required EmailContentType ContentType { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the notification order, of which this email is a part.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("notificationId")]
+    public required Guid NotificationId { get; init; }
+}

--- a/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
+++ b/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+
+using Altinn.Notifications.Email.Core.Sending;
+using Altinn.Notifications.Email.Models.InstantEmail;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Notifications.Email.IntegrationTests.InstantEmailController;
+
+public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebApplicationFactory<Controllers.InstantEmailController>>
+{
+    private readonly IntegrationTestWebApplicationFactory<Controllers.InstantEmailController> _factory;
+    private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public InstantEmailControllerTests(IntegrationTestWebApplicationFactory<Controllers.InstantEmailController> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public void InstantEmailController_HasApiExplorerSettingsWithIgnoreApiTrue()
+    {
+        // Arrange
+        var controllerType = typeof(Controllers.InstantEmailController);
+
+        // Act
+        var attribute = controllerType.GetCustomAttribute<ApiExplorerSettingsAttribute>();
+
+        // Assert
+        Assert.NotNull(attribute);
+        Assert.True(attribute.IgnoreApi);
+    }
+
+    [Fact]
+    public async Task Send_WhenRequestIsCanceled_Returns499ClientClosedRequest()
+    {
+        // Arrange
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock.Setup(s => s.SendAsync(It.IsAny<Core.Sending.Email>())).ThrowsAsync(new OperationCanceledException());
+
+        var instantEmailRequest = new InstantEmailRequest
+        {
+            Sender = "noreply@test.altinn.no",
+            Recipient = "test@example.com",
+            Subject = "Test Email",
+            Body = "This is a test email message.",
+            ContentType = EmailContentType.Plain,
+            NotificationId = Guid.NewGuid()
+        };
+
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        // Act
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+
+        // Assert
+        Assert.Equal((HttpStatusCode)499, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseBody, _jsonOptions);
+
+        Assert.NotNull(problemDetails);
+        Assert.Equal(499, problemDetails.Status);
+        Assert.Contains("Request terminated", problemDetails.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Send_WhenSendingServiceFails_ReturnsBadRequest()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock.Setup(e => e.SendAsync(It.IsAny<Core.Sending.Email>())).ThrowsAsync(new InvalidOperationException());
+
+        var instantEmailRequest = new InstantEmailRequest
+        {
+            Sender = "noreply@test.altinn.no",
+            Recipient = "test@example.com",
+            Subject = "Test Email Subject",
+            Body = "This is a test email with detailed content for testing purposes.",
+            ContentType = EmailContentType.Html,
+            NotificationId = notificationId
+        };
+
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        // Act
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseBody, _jsonOptions);
+
+        Assert.NotNull(problemDetails);
+        Assert.Equal(400, problemDetails.Status);
+    }
+
+    [Theory]
+    [InlineData("", "", "", "", "")] // All invalid
+    [InlineData("noreply@test.altinn.no", "test@example.com", "", "Valid body", "Plain")] // Invalid Subject
+    [InlineData("noreply@test.altinn.no", "test@example.com", "Valid subject", "", "Plain")] // Invalid Body
+    [InlineData("noreply@test.altinn.no", "", "Valid subject", "Valid body", "Plain")] // Invalid Recipient
+    [InlineData("", "test@example.com", "Valid subject", "Valid body", "Plain")] // Invalid Sender
+    [InlineData("noreply@test.altinn.no", "invalid-email", "Valid subject", "Valid body", "Plain")] // Invalid email format
+    [InlineData("noreply@test.altinn.no", "test@example.com", "Valid subject", "Valid body", "")] // Invalid ContentType
+    public async Task Send_WithInvalidRequestProperties_ReturnsBadRequestWithValidationError(string sender, string recipient, string subject, string body, string contentType)
+    {
+        // Arrange
+        var sendingServiceMock = new Mock<ISendingService>();
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        var jsonRequest = $$"""
+        {
+           "sender": "{{sender}}",
+           "recipient": "{{recipient}}",
+           "subject": "{{subject}}",
+           "body": "{{body}}",
+           "contentType": "{{contentType}}",
+           "notificationId": "00000000-0000-0000-0000-000000000000"
+        }
+        """;
+
+        var content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.PostAsync("/notifications/email/api/v1/instantemail/send", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseBody, _jsonOptions);
+
+        Assert.NotNull(problemDetails);
+        Assert.Equal(400, problemDetails.Status);
+        Assert.Equal("One or more validation errors occurred.", problemDetails.Title);
+    }
+
+    [Fact]
+    public async Task Send_WithValidPlainTextRequest_ReturnsOk()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock.Setup(e => e.SendAsync(It.Is<Core.Sending.Email>(e => e.NotificationId == notificationId))).Returns(Task.CompletedTask);
+
+        var instantEmailRequest = new InstantEmailRequest
+        {
+            Sender = "noreply@test.altinn.no",
+            Recipient = "test@example.com",
+            Subject = "Test Notification",
+            Body = "This is a plain text email notification sent instantly.",
+            ContentType = EmailContentType.Plain,
+            NotificationId = notificationId
+        };
+
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        // Act
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Send_WithValidHtmlRequest_ReturnsOk()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock.Setup(e => e.SendAsync(It.Is<Core.Sending.Email>(e => e.NotificationId == notificationId))).Returns(Task.CompletedTask);
+
+        var instantEmailRequest = new InstantEmailRequest
+        {
+            Sender = "noreply@test.altinn.no",
+            Recipient = "test@example.com",
+            Subject = "HTML Test Notification",
+            Body = "<html><body><h1>Test Email</h1><p>This is an <strong>HTML</strong> email notification.</p></body></html>",
+            ContentType = EmailContentType.Html,
+            NotificationId = notificationId
+        };
+
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        // Act
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Send_VerifiesCorrectMappingToEmailModel()
+    {
+        // Arrange
+        var notificationId = Guid.NewGuid();
+        Core.Sending.Email? capturedEmail = null;
+
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock.Setup(e => e.SendAsync(It.IsAny<Core.Sending.Email>()))
+            .Callback<Core.Sending.Email>(email => capturedEmail = email)
+            .Returns(Task.CompletedTask);
+
+        var instantEmailRequest = new InstantEmailRequest
+        {
+            Sender = "sender@test.altinn.no",
+            Recipient = "recipient@example.com",
+            Subject = "Mapping Test Subject",
+            Body = "Test body content for mapping verification",
+            ContentType = EmailContentType.Html,
+            NotificationId = notificationId
+        };
+
+        var httpClient = GetTestClient(sendingServiceMock.Object);
+
+        // Act
+        await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+
+        // Assert
+        Assert.NotNull(capturedEmail);
+        Assert.Equal(notificationId, capturedEmail.NotificationId);
+        Assert.Equal("Mapping Test Subject", capturedEmail.Subject);
+        Assert.Equal("Test body content for mapping verification", capturedEmail.Body);
+        Assert.Equal("sender@test.altinn.no", capturedEmail.FromAddress);
+        Assert.Equal("recipient@example.com", capturedEmail.ToAddress);
+        Assert.Equal(EmailContentType.Html, capturedEmail.ContentType);
+    }
+
+    private HttpClient GetTestClient(ISendingService sendingService)
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddSingleton(sendingService);
+            });
+        }).CreateClient();
+    }
+}

--- a/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
+++ b/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
@@ -61,7 +61,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var httpClient = GetTestClient(sendingServiceMock.Object);
 
         // Act
-        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail", instantEmailRequest);
 
         // Assert
         Assert.Equal((HttpStatusCode)499, response.StatusCode);
@@ -96,7 +96,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var httpClient = GetTestClient(sendingServiceMock.Object);
 
         // Act
-        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail", instantEmailRequest);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -136,7 +136,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
 
         // Act
-        var response = await httpClient.PostAsync("/notifications/email/api/v1/instantemail/send", content);
+        var response = await httpClient.PostAsync("/notifications/email/api/v1/instantemail", content);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -171,7 +171,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var httpClient = GetTestClient(sendingServiceMock.Object);
 
         // Act
-        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail", instantEmailRequest);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
@@ -200,7 +200,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var httpClient = GetTestClient(sendingServiceMock.Object);
 
         // Act
-        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+        var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail", instantEmailRequest);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
@@ -232,7 +232,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var httpClient = GetTestClient(sendingServiceMock.Object);
 
         // Act
-        await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
+        await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail", instantEmailRequest);
 
         // Assert
         Assert.NotNull(capturedEmail);

--- a/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
+++ b/test/Altinn.Notifications.Email.IntegrationTests/InstantEmailController/InstantEmailControllerTests.cs
@@ -150,7 +150,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Send_WithValidPlainTextRequest_ReturnsOk()
+    public async Task Send_WithValidPlainTextRequest_ReturnsAccepted()
     {
         // Arrange
         var notificationId = Guid.NewGuid();
@@ -174,11 +174,12 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        sendingServiceMock.Verify(e => e.SendAsync(It.IsAny<Core.Sending.Email>()), Times.Once);
     }
 
     [Fact]
-    public async Task Send_WithValidHtmlRequest_ReturnsOk()
+    public async Task Send_WithValidHtmlRequest_ReturnsAccepted()
     {
         // Arrange
         var notificationId = Guid.NewGuid();
@@ -202,11 +203,12 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         var response = await httpClient.PostAsJsonAsync("/notifications/email/api/v1/instantemail/send", instantEmailRequest);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        sendingServiceMock.Verify(e => e.SendAsync(It.IsAny<Core.Sending.Email>()), Times.Once);
     }
 
     [Fact]
-    public async Task Send_VerifiesCorrectMappingToEmailModel()
+    public async Task Send_WhenCalled_MapsRequestToDomainEmail()
     {
         // Arrange
         var notificationId = Guid.NewGuid();
@@ -240,6 +242,7 @@ public class InstantEmailControllerTests : IClassFixture<IntegrationTestWebAppli
         Assert.Equal("sender@test.altinn.no", capturedEmail.FromAddress);
         Assert.Equal("recipient@example.com", capturedEmail.ToAddress);
         Assert.Equal(EmailContentType.Html, capturedEmail.ContentType);
+        sendingServiceMock.Verify(e => e.SendAsync(It.IsAny<Core.Sending.Email>()), Times.Once);
     }
 
     private HttpClient GetTestClient(ISendingService sendingService)


### PR DESCRIPTION
Implement instant email delivery endpoint for immediate email dispatch

## Description
Add new internal REST endpoint `POST /notifications/email/api/v1/instantemail` that accepts email requests with the following payload format and forwards them directly to Azure Communication Services (bypassing the queue system):

```json
{
  "sender": "string",
  "recipient": "string",
  "subject": "string",
  "body": "string",
  "contentType": "Plain|Html",
  "notificationId": "GUID"
}
```

Key changes:
- New `InstantEmailRequest` model with proper validation and EmailContentType enum
- New `InstantEmailController` following SMS instant delivery patterns
- Integration tests covering validation, error handling, and success scenarios
- Similar error handling for the email service and the SMS service

## Related Issue(s)
- [#1042](https://github.com/Altinn/altinn-notifications/issues/1042)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
