### PR TITLE
Add a hint that the repository is no longer in use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ⚠️ This Repository Has Been Archived
+
+**This repository is no longer maintained.**
+
+The functionality from this repository has been merged into the main Altinn Notifications monorepo.
+
+👉 **Please use [altinn-notifications](https://github.com/Altinn/altinn-notifications) instead.**
+
+The email service component can be found at: [`components/email-service`](https://github.com/Altinn/altinn-notifications/tree/main/components/email-service).
+
+---
+
 # altinn-notifications-email
 
 This component handles the functionality related to sending an email through Altinn Notifications.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # ⚠️ This Repository Has Been Archived
 
-**This repository is no longer maintained.**
+**This repository is no longer being maintained.**
 
-The functionality from this repository has been merged into the main Altinn Notifications monorepo.
-
-👉 **Please use [altinn-notifications](https://github.com/Altinn/altinn-notifications) instead.**
+The application in this repository has been moved into the Altinn Notifications repository.
 
 The email service component can be found at: [`components/email-service`](https://github.com/Altinn/altinn-notifications/tree/main/components/email-service).
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 **This repository is no longer being maintained.**
 
-The application in this repository has been moved into the Altinn Notifications repository.
-
-The email service component can be found at: [`components/email-service`](https://github.com/Altinn/altinn-notifications/tree/main/components/email-service).
+The application in this repository has been moved into the Altinn Notifications repository and can be found at: [`components/email-service`](https://github.com/Altinn/altinn-notifications/tree/main/components/email-service).
 
 ---
 


### PR DESCRIPTION
## Description
Add a section to the README file indicating that the repository has been archived.

## Related Issue(s)
- #https://github.com/Altinn/altinn-notifications/issues/1324

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added archival notice to README indicating the repository is archived and functionality moved to Altinn Notifications.
  * Updated README to redirect users to the Altinn Notifications monorepo and point to the email-service component.
  * Preserved existing README content; changes are informational only and introduce no runtime or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->